### PR TITLE
Change Pkg function name in the README

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,4 +10,5 @@ Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+GrowableArrays = "0.1"
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Vector autoregressive models for Julia
 
 ## Installation
 ```julia
-Pkg.clone("https://github.com/lucabrugnolini/VectorAutoregressions.jl")
+Pkg.add("https://github.com/lucabrugnolini/VectorAutoregressions.jl")
 ```
 ## Introduction
 This package is a work in progress for the estimation and identification of Vector Autoregressive (VAR) models.
@@ -30,7 +30,7 @@ This package is a work in progress for the estimation and identification of Vect
       - [ ] Sign restrictions
       - [ ] Heteroskedasticity
       - [x] External instruments (ex. high-frequency,narrative)
-        - [x] Wild bootstrap 
+        - [x] Wild bootstrap
     - [x] Confidence bands
       - [x] Asymptotic
       - [x] Bootstrap
@@ -60,7 +60,7 @@ nrep = 500 #bootstrap sample
 V = VAR(y,p,intercept)
 
 # Estimate IRFs - Cholesky identification
-T,K = size(y) 
+T,K = size(y)
 mIRFa = IRFs_a(V,H,intercept) #asymptotic conf. bandf
 mIRFb = IRFs_b(V,H,nrep,intercept) #bootstrap conf. bands
 


### PR DESCRIPTION
Hi, 

very minor point. `Pkg.clone` is part of the old API. The new API is using 

```julia
using Pkg
pkg"add <URL or package name>"
```
to install packages. 

For this package the README should use the following command. 

```julia
using Pkg
Pkg.add("https://github.com/lucabrugnolini/VectorAutoregressions.jl")
```

