### PR TITLE
Create documentation page

### DIFF
--- a/.github/workflows/Documenter.yml
+++ b/.github/workflows/Documenter.yml
@@ -1,0 +1,23 @@
+name: Documenter
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: '1.7'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env: 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia --project=docs/ docs/make.jl
+        

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # VectorAutoregressions.jl
 Vector autoregressive models for Julia
 
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://github.com/lucabrugnolini/VectorAutoregressions.jl/stable)
 [![Build Status](https://travis-ci.org/lucabrugnolini/VectorAutoregressions.jl.svg?branch=master)](https://travis-ci.org/lucabrugnolini/VectorAutoregressions.jl)
 [![Coverage Status](https://coveralls.io/repos/github/lucabrugnolini/VectorAutoregressions.jl/badge.svg?branch=master)](https://coveralls.io/github/lucabrugnolini/VectorAutoregressions.jl?branch=master)
 [![codecov](https://codecov.io/gh/lucabrugnolini/VectorAutoregressions.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/lucabrugnolini/VectorAutoregressions.jl)

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+build/
+site/

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,6 @@ makedocs(
 # Documenter can also automatically deploy documentation to gh-pages.
 # See "Hosting Documentation" and deploydocs() in the Documenter manual
 # for more information.
-#=deploydocs(
-    repo = "<repository url>"
-)=#
+deploydocs(
+    repo = "github.com/lucabrugnolini/VectorAutoregressions.jl.git"
+)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,15 @@
+using Documenter
+using VectorAutoregressions
+
+makedocs(
+    sitename = "VectorAutoregressions",
+    format = Documenter.HTML(),
+    modules = [VectorAutoregressions]
+)
+
+# Documenter can also automatically deploy documentation to gh-pages.
+# See "Hosting Documentation" and deploydocs() in the Documenter manual
+# for more information.
+#=deploydocs(
+    repo = "<repository url>"
+)=#

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,3 @@
+# VectorAutoregressions.jl
+
+Documentation for VectorAutoregressions.jl


### PR DESCRIPTION
I've added all the code necessary to create a documentation page for the package hosted on GitHub Pages. 

To make this work, an owner of the repo needs to set up deploy keys through GitHub (if unsure, check out https://youtu.be/Vi4Ntd_Vf4A?t=223 for a straight-forward tutorial on this). 

Once the above is done, the documentation should automatically be accessible at https://lucabrugnlini.github.io/VectorAutoregressions.jl/dev once the action runs. If not, then go to `Settings` then `Pages`, and make sure that the GitHub Pages directory is set to the `dev` subdirectory in the master branch.

Let me know if you run into any trouble. I'll start adding docstrings to the functions once this pull request goes through.